### PR TITLE
Patch ZeroMQ building

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -29,5 +29,6 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  sed -i.old "s/ -lstdc++//" lib/pkgconfig/libzmq.pc && \
   rm -rf bin share
 endef

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -3,7 +3,7 @@ $(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
-$(package)_patches=no_osx_unused_const.patch
+$(package)_patches=no_osx_unused_const.patch remove_libstd_link.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--without-documentation --disable-shared --without-libsodium --disable-curve
@@ -13,7 +13,8 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/no_osx_unused_const.patch && \
-  ./autogen.sh
+  patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config
 endef
 
 define $(package)_config_cmds
@@ -29,6 +30,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  sed -i.old "s/ -lstdc++//" lib/pkgconfig/libzmq.pc && \
-  rm -rf bin share
+  rm -rf bin share lib/*.la
 endef

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -3,7 +3,7 @@ $(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
-$(package)_patches=no_osx_unused_const.patch remove_libstd_link.patch
+$(package)_patches=remove_libstd_link.patch no_osx_unused_const.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--without-documentation --disable-shared --without-libsodium --disable-curve
@@ -14,6 +14,7 @@ endef
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/no_osx_unused_const.patch && \
   patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
+  patch -p1 < $($(package)_patch_dir)/0002-disable-pthread_set_name_np.patch && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config
 endef
 

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -3,6 +3,7 @@ $(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
+$(package)_patches=no_osx_unused_const.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--without-documentation --disable-shared --without-libsodium --disable-curve
@@ -11,6 +12,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/no_osx_unused_const.patch && \
   ./autogen.sh
 endef
 

--- a/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
+++ b/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
@@ -1,0 +1,29 @@
+From 6e6b47d5ab381c3df3b30bb0b0a6cf210dfb1eba Mon Sep 17 00:00:00 2001
+From: Cory Fields <cory-nospam-@coryfields.com>
+Date: Mon, 5 Mar 2018 14:22:05 -0500
+Subject: [PATCH] disable pthread_set_name_np
+
+pthread_set_name_np adds a Glibc requirement on >= 2.12.
+---
+ src/thread.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- zeromq-4.3.4-orig/src/thread.cpp	2021-01-03 21:46:01.000000000 +0000
++++ zeromq-4.3.4/src/thread.cpp	2021-07-01 22:42:49.850117319 +0100
+@@ -393,6 +393,7 @@
+     return;
+ #endif
+ 
++#if 0
+ #if defined(ZMQ_HAVE_PTHREAD_SETNAME_1)
+     int rc = pthread_setname_np (_name);
+     if (rc)
+@@ -408,6 +409,8 @@
+ #elif defined(ZMQ_HAVE_PTHREAD_SET_NAME)
+     pthread_set_name_np (pthread_self (), _name);
+ #endif
++#endif
++    return;
+ }
+ 
+ #endif

--- a/depends/patches/zeromq/no_osx_unused_const.patch
+++ b/depends/patches/zeromq/no_osx_unused_const.patch
@@ -1,0 +1,13 @@
+diff -U3 -r zeromq-4.3.4-orig/src/clock.cpp zeromq-4.3.4/src/clock.cpp
+--- zeromq-4.3.4-orig/src/clock.cpp	2021-01-03 21:46:01.000000000 +0000
++++ zeromq-4.3.4/src/clock.cpp	2021-07-01 20:27:35.348783385 +0100
+@@ -128,7 +128,9 @@
+ 
+ const uint64_t usecs_per_msec = 1000;
+ const uint64_t usecs_per_sec = 1000000;
++#ifndef ZMQ_HAVE_OSX
+ const uint64_t nsecs_per_usec = 1000;
++#endif
+ 
+ zmq::clock_t::clock_t () :
+     _last_tsc (rdtsc ()),

--- a/depends/patches/zeromq/remove_libstd_link.patch
+++ b/depends/patches/zeromq/remove_libstd_link.patch
@@ -1,0 +1,25 @@
+commit 47d4cd12a2c051815ddda78adebdb3923b260d8a
+Author: fanquake <fanquake@gmail.com>
+Date:   Tue Aug 18 14:45:40 2020 +0800
+
+    Remove needless linking against libstdc++
+
+    This is broken for a number of reasons, including:
+    - g++ understands "static-libstdc++ -lstdc++" to mean "link against
+      whatever libstdc++ exists, probably shared", which in itself is buggy.
+    - another stdlib (libc++ for example) may be in use
+
+    See #11981.
+
+diff --git a/src/libzmq.pc.in b/src/libzmq.pc.in
+index 233bc3a..3c2bf0d 100644
+--- a/src/libzmq.pc.in
++++ b/src/libzmq.pc.in
+@@ -7,6 +7,6 @@ Name: libzmq
+ Description: 0MQ c++ library
+ Version: @VERSION@
+ Libs: -L${libdir} -lzmq
+-Libs.private: -lstdc++ @pkg_config_libs_private@
++Libs.private: @pkg_config_libs_private@
+ Requires.private: @pkg_config_names_private@
+ Cflags: -I${includedir} @pkg_config_defines@


### PR DESCRIPTION
* Fix an error on OS X due to an unused constant.
* Cherry-pick in patches from upstream to fix build issues on Linux.
