### PR TITLE
[depends] patch unused nsecs_per_usec var in zmq clock.cpp

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -3,6 +3,7 @@ $(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
+$(package)_patches=clock-unused-nsecs.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--without-documentation --disable-shared --without-libsodium --disable-curve
@@ -11,6 +12,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/clock-unused-nsecs.patch && \
   ./autogen.sh
 endef
 

--- a/depends/patches/zeromq/clock-unused-nsecs.patch
+++ b/depends/patches/zeromq/clock-unused-nsecs.patch
@@ -1,0 +1,11 @@
+diff -dur a/src/clock.cpp b/src/clock.cpp
+--- a/src/clock.cpp	2021-07-12 21:15:35.111146311 +0000
++++ b/src/clock.cpp	2021-07-12 21:22:09.059753013 +0000
+@@ -194,6 +194,7 @@
+ #else
+
+     //  Use POSIX gettimeofday function to get precise time.
++    LIBZMQ_UNUSED (nsecs_per_usec);
+     struct timeval tv;
+     int rc = gettimeofday (&tv, NULL);
+     errno_assert (rc == 0);


### PR DESCRIPTION
Fixes the issue with clang not liking the unused static.