### PR TITLE
depends: Patch windows net headers for trusty

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -4,6 +4,7 @@ $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
 $(package)_patches=remove_libstd_link.patch clock-unused-nsecs.patch 0002-disable-pthread_set_name_np.patch
+$(package)_patches+=trusty-add-win32-inethdr.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--without-documentation --disable-shared --without-libsodium --disable-curve
@@ -15,6 +16,7 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/clock-unused-nsecs.patch && \
   patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
   patch -p1 < $($(package)_patch_dir)/0002-disable-pthread_set_name_np.patch && \
+	patch -p1 < $($(package)_patch_dir)/trusty-add-win32-inethdr.patch && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config
 endef
 

--- a/depends/patches/zeromq/trusty-add-win32-inethdr.patch
+++ b/depends/patches/zeromq/trusty-add-win32-inethdr.patch
@@ -1,0 +1,11 @@
+diff -dur a/src/windows.hpp b/src/windows.hpp
+--- a/src/windows.hpp	2021-07-16 20:31:22.997078113 +0000
++++ b/src/windows.hpp	2021-07-16 20:33:21.525281189 +0000
+@@ -52,6 +52,7 @@
+ #endif
+
+ #include <winsock2.h>
++#include <ws2ipdef.h>
+ #include <windows.h>
+ #include <mswsock.h>
+ #include <iphlpapi.h>


### PR DESCRIPTION
Fixes the issue that "'SOCKADDR_INET' does not name a type" when compiling under trusty with mingw 3.1.0 headers by adding ws2ipdef.h